### PR TITLE
Postprocessing: change thr by class to remove small obj

### DIFF
--- a/model_seg_sctumor-edema-cavity_t2-t1_unet3d-multichannel.json
+++ b/model_seg_sctumor-edema-cavity_t2-t1_unet3d-multichannel.json
@@ -108,7 +108,7 @@
             "thr": 0.5
         },
         "remove_small": {
-            "thr": 100,
+            "thr": [100, 250, 250, 100],
             "unit": "vox"
         },
         "fill_holes": {}


### PR DESCRIPTION
ivadomed and SCT will become compliant to remove small objects by class with these PRs respectively: https://github.com/ivadomed/ivadomed/pull/570 and https://github.com/neuropoly/spinalcordtoolbox/pull/3090